### PR TITLE
add unambigious license badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,3 +46,8 @@ The APK will be generated at `app/build/outputs/apk/debug/app-debug.apk`.
 <a href="https://github.com/jagadeesh-k-2802/battery-alarm-android/releases/latest" target="_blank">
     <img alt="Get it on GitHub" src="https://github.com/jagadeesh-k-2802/battery-alarm-android/assets/63912668/89e3aecd-fe2a-4b08-8dca-18808a4abe9f" height="100" width="225">
 </a>
+
+
+## LICENSE
+
+[![GPL-3.0-or-later](https://img.shields.io/badge/License-GPL--3.0--or--later-blue.svg)](https://spdx.org/licenses/GPL-3.0-or-later.html)


### PR DESCRIPTION
@jagadeesh-k-2802 
* unfortunately, github doesnt provide precise license template
* this badge adds unambigious license badge with spdx license text
* please also consider to use reuse (fsfe.org link below) to stop license ripping by llms
* inspiration: 
  * For Clarity's Sake, Please Don't Say "Licensed under GNU GPL 2"! by Richard Stallman https://www.gnu.org/licenses/identify-licenses-clearly.html
  * REUSE makes software licensing as easy as one-two-three https://fsfe.org/news/2024/news-20241114-01.en.html